### PR TITLE
Add background location sharing

### DIFF
--- a/mobileapp/android/app/src/main/AndroidManifest.xml
+++ b/mobileapp/android/app/src/main/AndroidManifest.xml
@@ -4,7 +4,10 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-        
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+
     <application
       android:name=".MainApplication"
       android:label="@string/app_name"
@@ -31,6 +34,7 @@
         </intent-filter>
       </activity>
       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+      <service android:name="com.asterinet.react.bgactions.RNBackgroundActionsTask" />
     </application>
 
 </manifest>

--- a/mobileapp/package-lock.json
+++ b/mobileapp/package-lock.json
@@ -2147,6 +2147,14 @@
         "chalk": "^3.0.0"
       }
     },
+    "@react-native-async-storage/async-storage": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.15.4.tgz",
+      "integrity": "sha512-pC0MS6UBuv/YiVAxtzi7CgUed8oCQNYMtGt0yb/I9fI/BWTiJK5cj4YtW2XtL95K5IuvPX/6uGWaouZ8KqXwdg==",
+      "requires": {
+        "deep-assign": "^3.0.0"
+      }
+    },
     "@react-native-community/cli-debugger-ui": {
       "version": "4.13.1",
       "resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-4.13.1.tgz",
@@ -3565,6 +3573,14 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    },
+    "deep-assign": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-3.0.0.tgz",
+      "integrity": "sha512-YX2i9XjJ7h5q/aQ/IM9PEwEnDqETAIYbggmdDB3HLTlSgo1CxPsj6pvhPG68rq6SVE0+p+6Ywsm5fTYNrYtBWw==",
+      "requires": {
+        "is-obj": "^1.0.0"
+      }
     },
     "deep-is": {
       "version": "0.1.3",
@@ -5486,6 +5502,11 @@
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
       "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
       "dev": true
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-plain-object": {
       "version": "2.0.4",

--- a/mobileapp/package-lock.json
+++ b/mobileapp/package-lock.json
@@ -9815,6 +9815,21 @@
         }
       }
     },
+    "react-native-background-actions": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-native-background-actions/-/react-native-background-actions-2.6.0.tgz",
+      "integrity": "sha512-CVUUmuYLVF1e2pFotKWZJi0u8C47U5lQ+KNNqJH8TqMgTLUX+7LyJq4N6a/6Bq1DjpwMTj+pZFAb4LGa0qiLvA==",
+      "requires": {
+        "eventemitter3": "^4.0.7"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "4.0.7",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+          "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+        }
+      }
+    },
     "react-native-geolocation-service": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/react-native-geolocation-service/-/react-native-geolocation-service-5.2.0.tgz",

--- a/mobileapp/package.json
+++ b/mobileapp/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "react": "16.13.1",
     "react-native": "0.63.4",
+    "react-native-background-actions": "^2.6.0",
     "react-native-geolocation-service": "^5.2.0",
     "restapi-client": "file:restapi-client-0.1.0.tgz"
   },

--- a/mobileapp/package.json
+++ b/mobileapp/package.json
@@ -12,6 +12,7 @@
     "update:restapi": "npm pack ../restapi/client && npm install restapi-client-0.1.0.tgz && react-native start --reset-cache"
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "^1.15.4",
     "react": "16.13.1",
     "react-native": "0.63.4",
     "react-native-background-actions": "^2.6.0",

--- a/mobileapp/package.json
+++ b/mobileapp/package.json
@@ -35,7 +35,7 @@
       "./src/setup-tests.js"
     ],
     "transformIgnorePatterns": [
-      "node_modules/(?!(react-native|react-native-geolocation-service|restapi-client)/)"
+      "node_modules/(?!(react-native|react-native-geolocation-service|react-native-background-actions|restapi-client)/)"
     ]
   }
 }

--- a/mobileapp/src/App.js
+++ b/mobileapp/src/App.js
@@ -14,16 +14,12 @@ import {
   View,
   Text,
   Image,
-  StatusBar,
-  Linking,
+  StatusBar
 } from 'react-native';
 
 import {
   Header,
-  LearnMoreLinks,
   Colors,
-  DebugInstructions,
-  ReloadInstructions,
 } from 'react-native/Libraries/NewAppScreen';
 
 import Dashboard from './components/Dashboard';

--- a/mobileapp/src/App.js
+++ b/mobileapp/src/App.js
@@ -26,13 +26,11 @@ import Dashboard from './components/Dashboard';
 import LoginForm from './components/LoginForm';
 import SessionProvider from './components/session/SessionProvider';
 import { SessionContext } from './components/session/SessionContext';
-import { connectSocket } from './Socket'
 
 class App extends React.Component { 
 
   constructor(props) {
     super(props);
-    connectSocket();
   }
 
   render() {

--- a/mobileapp/src/App.test.js
+++ b/mobileapp/src/App.test.js
@@ -9,8 +9,6 @@ import App from './App';
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';
 
-jest.mock('./Socket');
-
 test('renders correctly', () => {
   renderer.create(<App />);
 });

--- a/mobileapp/src/GeolocationService.js
+++ b/mobileapp/src/GeolocationService.js
@@ -4,189 +4,195 @@ import { updateLastLocation } from 'restapi-client';
 import BackgroundService from "react-native-background-actions";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
-export async function fetchLocation(callback) {
-
-    const permission = await hasLocationPermission();
-    if (!permission) {
-        console.log("We have no permission!");
-        return;
-    }
-
-    let success = (position) => {
-        console.log("GEOLOCATION OBTAINED: ", position);
-        callback(position.coords.latitude, position.coords.longitude);
-    };
-    let err = (msg) => {
-        console.log("COULD NOT FIND LOCATION: ", msg);
-        console.log("Defaulting to (null, null)");
-        callback(null, null);
-
-    };
-    let config = {
-        enableHighAccuracy: false,
-        timeout: 20000
-    };
-    geoloc.getCurrentPosition(success, err, config);
-}
-
 const backgroundLocationSharingKey = "background-location-sharing";
 
-export async function autoStartBackgroundLocationSharing(sessionId) {
-    let start = false;
-    try {
-        const value = await AsyncStorage.getItem(backgroundLocationSharingKey);
-        start = value === "true";
-    } catch(err) {
-        console.log(`failed to read '${backgroundLocationSharingKey}':`, err);
-    }
+class GeolocationService {
+    async fetchLocation(callback) {
 
-    if (start) {
-        await startBackgroundLocationSharing(sessionId);
-    }
-}
-
-export async function startBackgroundLocationSharing(sessionId) {
-    const permission = await hasLocationPermission();
-    if (!permission) {
-        console.log("No permission to get locations, not starting background location sharing.");
-        return;
-    }
-
-    const backgroundPermission = await hasBackgroundLocationPermission();
-    if (!backgroundPermission) {
-        console.log("No permission to get locations in the background, starting background location sharing but will only work when using the app.");
-        ToastAndroid.show('Radarin needs location access all the time to share your location with your friends while this app is not active.', ToastAndroid.LONG);
-    }
-
-    const taskOptions = {
-        taskName: 'radarinen2a-background-location-sharing',
-        taskTitle: 'Radarin: Location Sharing',
-        taskDesc: 'Radarin is sharing your location with your friends.',
-        taskIcon: {
-            name: 'ic_launcher',
-            type: 'mipmap',
-        },
-        color: '#ff00ff',
-        linkingURI: 'radarinen2a://',
-        parameters: {
-            sessionId: sessionId,
+        const permission = await this.hasLocationPermission();
+        if (!permission) {
+            console.log("We have no permission!");
+            return;
         }
+
+        let success = (position) => {
+            console.log("GEOLOCATION OBTAINED: ", position);
+            callback(position.coords.latitude, position.coords.longitude);
+        };
+        let err = (msg) => {
+            console.log("COULD NOT FIND LOCATION: ", msg);
+            console.log("Defaulting to (null, null)");
+            callback(null, null);
+
+        };
+        let config = {
+            enableHighAccuracy: false,
+            timeout: 20000
+        };
+        geoloc.getCurrentPosition(success, err, config);
+    }
+
+    async autoStartBackgroundLocationSharing(sessionId) {
+        let start = false;
+        try {
+            const value = await AsyncStorage.getItem(backgroundLocationSharingKey);
+            start = value === "true";
+        } catch(err) {
+            console.log(`failed to read '${backgroundLocationSharingKey}':`, err);
+        }
+
+        if (start) {
+            await this.startBackgroundLocationSharing(sessionId);
+        }
+    }
+
+    async startBackgroundLocationSharing(sessionId) {
+        const permission = await this.hasLocationPermission();
+        if (!permission) {
+            console.log("No permission to get locations, not starting background location sharing.");
+            return;
+        }
+
+        const backgroundPermission = await this.hasBackgroundLocationPermission();
+        if (!backgroundPermission) {
+            console.log("No permission to get locations in the background, starting background location sharing but will only work when using the app.");
+            ToastAndroid.show('Radarin needs location access all the time to share your location with your friends while this app is not active.', ToastAndroid.LONG);
+        }
+
+        const taskOptions = {
+            taskName: 'radarinen2a-background-location-sharing',
+            taskTitle: 'Radarin: Location Sharing',
+            taskDesc: 'Radarin is sharing your location with your friends.',
+            taskIcon: {
+                name: 'ic_launcher',
+                type: 'mipmap',
+            },
+            color: '#ff00ff',
+            linkingURI: 'radarinen2a://',
+            parameters: {
+                sessionId: sessionId,
+            }
+        };
+
+        try {
+            await AsyncStorage.setItem(backgroundLocationSharingKey, "true");
+        } catch (err) {
+            console.log(`failed to save '${backgroundLocationSharingKey}':`, err);
+        }
+
+        await BackgroundService.start(this.backgroundLocationSharingTask, taskOptions);
+    }
+
+    async stopBackgroundLocationSharing() {
+        try {
+            await AsyncStorage.setItem(backgroundLocationSharingKey, "false");
+        } catch (err) {
+            console.log(`failed to save '${backgroundLocationSharingKey}':`, err);
+        }
+
+        await BackgroundService.stop();
+    }
+
+    isBackgroundLocationSharingRunning() {
+        return BackgroundService.isRunning();
+    }
+
+    async backgroundLocationSharingTask(params) {
+        const delay = 30000; // share every 30 seconds
+        const sleep = time => new Promise(resolve => setTimeout(() => resolve(), time));
+        
+        const { sessionId } = params;
+        await new Promise(async _ => {
+            let lastSharedLatitude = null, lastSharedLongitude = null;
+            while (this.isBackgroundLocationSharingRunning()) { // infinite task
+                await fetchLocation((lat, long) => {
+                    if (lat !== null && long !== null) { // have we received a valid location?
+                        if (lastSharedLatitude === null || lastSharedLongitude === null || lastSharedLatitude !== lat || lastSharedLongitude !== long) { // is it different from last time?
+                            updateLastLocation(sessionId, lat, long)
+                                .catch(err => console.log("Failed to share location: ", err));
+                            lastSharedLatitude = lat;
+                            lastSharedLongitude = long;
+                        }
+                    }
+                });
+                await sleep(delay);
+            }
+        });
+    }
+
+    async hasLocationPermission() {
+        if (Platform.OS === 'android' && Platform.Version < 23) {
+            return true;
+        }
+
+        const hasPermission = await PermissionsAndroid.check(
+            PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION,
+        ) || await PermissionsAndroid.check(
+            PermissionsAndroid.PERMISSIONS.ACCESS_BACKGROUND_LOCATION,
+        );
+
+        if (hasPermission) {
+            return true;
+        }
+
+        const status = await PermissionsAndroid.request(
+            PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION,
+        );
+
+        if (status === PermissionsAndroid.RESULTS.GRANTED) {
+            return true;
+        }
+
+        if (status === PermissionsAndroid.RESULTS.DENIED) {
+            ToastAndroid.show(
+                'Location permission denied by user.',
+                ToastAndroid.LONG,
+            );
+        } else if (status === PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN) {
+            ToastAndroid.show(
+                'Location permission revoked by user.',
+                ToastAndroid.LONG,
+            );
+        }
+        return false;
     };
 
-    try {
-        await AsyncStorage.setItem(backgroundLocationSharingKey, "true");
-    } catch (err) {
-        console.log(`failed to save '${backgroundLocationSharingKey}':`, err);
-    }
-
-    await BackgroundService.start(backgroundLocationSharingTask, taskOptions);
-}
-
-export async function stopBackgroundLocationSharing() {
-    try {
-        await AsyncStorage.setItem(backgroundLocationSharingKey, "false");
-    } catch (err) {
-        console.log(`failed to save '${backgroundLocationSharingKey}':`, err);
-    }
-
-    await BackgroundService.stop();
-}
-
-export function isBackgroundLocationSharingRunning() {
-    return BackgroundService.isRunning();
-}
-
-async function backgroundLocationSharingTask(params) {
-    const delay = 30000; // share every 30 seconds
-    const sleep = time => new Promise(resolve => setTimeout(() => resolve(), time));
-    
-    const { sessionId } = params;
-    await new Promise(async _ => {
-        let lastSharedLatitude = null, lastSharedLongitude = null;
-        while (BackgroundService.isRunning()) { // infinite task
-            await fetchLocation((lat, long) => {
-                if (lat !== null && long !== null) { // have we received a valid location?
-                    if (lastSharedLatitude === null || lastSharedLongitude === null || lastSharedLatitude !== lat || lastSharedLongitude !== long) { // is it different from last time?
-                        updateLastLocation(sessionId, lat, long)
-                            .catch(err => console.log("Failed to share location: ", err));
-                        lastSharedLatitude = lat;
-                        lastSharedLongitude = long;
-                    }
-                }
-            });
-            await sleep(delay);
+    async hasBackgroundLocationPermission() {
+        if (Platform.OS === 'android' && Platform.Version < 29) {
+            return true;
         }
-    });
+
+        const hasPermission = await PermissionsAndroid.check(
+            PermissionsAndroid.PERMISSIONS.ACCESS_BACKGROUND_LOCATION,
+        );
+
+        if (hasPermission) {
+            return true;
+        }
+
+        const status = await PermissionsAndroid.request(
+            PermissionsAndroid.PERMISSIONS.ACCESS_BACKGROUND_LOCATION
+        );
+
+        if (status === PermissionsAndroid.RESULTS.GRANTED) {
+            return true;
+        }
+
+        if (status === PermissionsAndroid.RESULTS.DENIED) {
+            ToastAndroid.show(
+                'Location permission denied by user.',
+                ToastAndroid.LONG,
+            );
+        } else if (status === PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN) {
+            ToastAndroid.show(
+                'Location permission revoked by user.',
+                ToastAndroid.LONG,
+            );
+        }
+        return false;
+    };
 }
 
-async function hasLocationPermission() {
-    if (Platform.OS === 'android' && Platform.Version < 23) {
-        return true;
-    }
+const GeolocationServiceInstance = new GeolocationService();
 
-    const hasPermission = await PermissionsAndroid.check(
-        PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION,
-    ) || await PermissionsAndroid.check(
-        PermissionsAndroid.PERMISSIONS.ACCESS_BACKGROUND_LOCATION,
-    );
-
-    if (hasPermission) {
-        return true;
-    }
-
-    const status = await PermissionsAndroid.request(
-        PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION,
-    );
-
-    if (status === PermissionsAndroid.RESULTS.GRANTED) {
-        return true;
-    }
-
-    if (status === PermissionsAndroid.RESULTS.DENIED) {
-        ToastAndroid.show(
-            'Location permission denied by user.',
-            ToastAndroid.LONG,
-        );
-    } else if (status === PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN) {
-        ToastAndroid.show(
-            'Location permission revoked by user.',
-            ToastAndroid.LONG,
-        );
-    }
-    return false;
-};
-
-async function hasBackgroundLocationPermission() {
-    if (Platform.OS === 'android' && Platform.Version < 29) {
-        return true;
-    }
-
-    const hasPermission = await PermissionsAndroid.check(
-        PermissionsAndroid.PERMISSIONS.ACCESS_BACKGROUND_LOCATION,
-    );
-
-    if (hasPermission) {
-        return true;
-    }
-
-    const status = await PermissionsAndroid.request(
-        PermissionsAndroid.PERMISSIONS.ACCESS_BACKGROUND_LOCATION
-    );
-
-    if (status === PermissionsAndroid.RESULTS.GRANTED) {
-        return true;
-    }
-
-    if (status === PermissionsAndroid.RESULTS.DENIED) {
-        ToastAndroid.show(
-            'Location permission denied by user.',
-            ToastAndroid.LONG,
-        );
-    } else if (status === PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN) {
-        ToastAndroid.show(
-            'Location permission revoked by user.',
-            ToastAndroid.LONG,
-        );
-    }
-    return false;
-};
+export default GeolocationServiceInstance;

--- a/mobileapp/src/GeolocationService.js
+++ b/mobileapp/src/GeolocationService.js
@@ -1,0 +1,162 @@
+import { Platform, PermissionsAndroid, Rationale, ToastAndroid } from 'react-native';
+import geoloc from 'react-native-geolocation-service';
+import { updateLastLocation } from 'restapi-client';
+import BackgroundService from "react-native-background-actions";
+
+export async function fetchLocation(callback) {
+
+    const permission = await hasLocationPermission();
+    if (!permission) {
+        console.log("We have no permission!");
+        return;
+    }
+
+    let success = (position) => {
+        console.log("GEOLOCATION OBTAINED: ", position);
+        callback(position.coords.latitude, position.coords.longitude);
+    };
+    let err = (msg) => {
+        console.log("COULD NOT FIND LOCATION: ", msg);
+        console.log("Defaulting to (null, null)");
+        callback(null, null);
+
+    };
+    let config = {
+        enableHighAccuracy: false,
+        timeout: 20000
+    };
+    geoloc.getCurrentPosition(success, err, config);
+}
+
+export async function startBackgroundLocationSharing(sessionId) {
+    const permission = await hasLocationPermission();
+    if (!permission) {
+        console.log("No permission to get locations, not starting background location sharing.");
+        return;
+    }
+
+    const backgroundPermission = await hasBackgroundLocationPermission();
+    if (!backgroundPermission) {
+        console.log("No permission to get locations in the background, starting background location sharing but will only work when using the app.");
+        ToastAndroid.show('Radarin needs location access all the time to share your location with your friends while this app is not active.', ToastAndroid.LONG);
+    }
+
+    const taskOptions = {
+        taskName: 'radarinen2a-background-location-sharing',
+        taskTitle: 'Radarin: Location Sharing',
+        taskDesc: 'Radarin is sharing your location with your friends.',
+        taskIcon: {
+            name: 'ic_launcher',
+            type: 'mipmap',
+        },
+        color: '#ff00ff',
+        linkingURI: 'radarinen2a://',
+        parameters: {
+            sessionId: sessionId,
+        }
+    };
+    await BackgroundService.start(backgroundLocationSharingTask, taskOptions)
+}
+
+export async function stopBackgroundLocationSharing() {
+    await BackgroundService.stop();
+}
+
+export function isBackgroundLocationSharingRunning() {
+    return BackgroundService.isRunning();
+}
+
+async function backgroundLocationSharingTask(params) {
+    const delay = 30000; // share every 30 seconds
+    const sleep = time => new Promise(resolve => setTimeout(() => resolve(), time));
+    
+    const { sessionId } = params;
+    await new Promise(async _ => {
+        let lastSharedLatitude = null, lastSharedLongitude = null;
+        while (BackgroundService.isRunning()) { // infinite task
+            await fetchLocation((lat, long) => {
+                if (lat !== null && long !== null) { // have we received a valid location?
+                    if (lastSharedLatitude === null || lastSharedLongitude === null || lastSharedLatitude !== lat || lastSharedLongitude !== long) { // is it different from last time?
+                        updateLastLocation(sessionId, lat, long)
+                            .catch(err => console.log("Failed to share location: ", err));
+                        lastSharedLatitude = lat;
+                        lastSharedLongitude = long;
+                    }
+                }
+            });
+            await sleep(delay);
+        }
+    });
+}
+
+async function hasLocationPermission() {
+    if (Platform.OS === 'android' && Platform.Version < 23) {
+        return true;
+    }
+
+    const hasPermission = await PermissionsAndroid.check(
+        PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION,
+    ) || await PermissionsAndroid.check(
+        PermissionsAndroid.PERMISSIONS.ACCESS_BACKGROUND_LOCATION,
+    );
+
+    if (hasPermission) {
+        return true;
+    }
+
+    const status = await PermissionsAndroid.request(
+        PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION,
+    );
+
+    if (status === PermissionsAndroid.RESULTS.GRANTED) {
+        return true;
+    }
+
+    if (status === PermissionsAndroid.RESULTS.DENIED) {
+        ToastAndroid.show(
+            'Location permission denied by user.',
+            ToastAndroid.LONG,
+        );
+    } else if (status === PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN) {
+        ToastAndroid.show(
+            'Location permission revoked by user.',
+            ToastAndroid.LONG,
+        );
+    }
+    return false;
+};
+
+async function hasBackgroundLocationPermission() {
+    if (Platform.OS === 'android' && Platform.Version < 29) {
+        return true;
+    }
+
+    const hasPermission = await PermissionsAndroid.check(
+        PermissionsAndroid.PERMISSIONS.ACCESS_BACKGROUND_LOCATION,
+    );
+
+    if (hasPermission) {
+        return true;
+    }
+
+    const status = await PermissionsAndroid.request(
+        PermissionsAndroid.PERMISSIONS.ACCESS_BACKGROUND_LOCATION
+    );
+
+    if (status === PermissionsAndroid.RESULTS.GRANTED) {
+        return true;
+    }
+
+    if (status === PermissionsAndroid.RESULTS.DENIED) {
+        ToastAndroid.show(
+            'Location permission denied by user.',
+            ToastAndroid.LONG,
+        );
+    } else if (status === PermissionsAndroid.RESULTS.NEVER_ASK_AGAIN) {
+        ToastAndroid.show(
+            'Location permission revoked by user.',
+            ToastAndroid.LONG,
+        );
+    }
+    return false;
+};

--- a/mobileapp/src/GeolocationService.test.js
+++ b/mobileapp/src/GeolocationService.test.js
@@ -1,0 +1,46 @@
+/**
+ * @format
+ */
+
+import 'react-native';
+import GeolocationService from './GeolocationService';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import BackgroundService from 'react-native-background-actions';
+
+beforeEach(async () => {
+    BackgroundService.start.mockReset();
+    BackgroundService.stop.mockReset();
+})
+
+test('autostarts if setting is true', async () => {
+    AsyncStorage.getItem.mockResolvedValueOnce("true");
+    GeolocationService.hasLocationPermission = jest.fn().mockResolvedValueOnce(true);
+    GeolocationService.hasBackgroundLocationPermission = jest.fn().mockResolvedValueOnce(true);
+    GeolocationService.startBackgroundLocationSharing = jest.fn().mockImplementation(GeolocationService.startBackgroundLocationSharing);
+
+    await GeolocationService.autoStartBackgroundLocationSharing("test");
+
+    expect(GeolocationService.startBackgroundLocationSharing).toHaveBeenCalledTimes(1);
+    expect(GeolocationService.startBackgroundLocationSharing).toHaveBeenCalledWith("test");
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith("background-location-sharing", "true");
+    expect(BackgroundService.start).toHaveBeenCalledTimes(1);
+});
+
+test('does not autostart if setting is false', async () => {
+    AsyncStorage.getItem.mockResolvedValueOnce("false");
+    GeolocationService.hasLocationPermission = jest.fn().mockResolvedValueOnce(true);
+    GeolocationService.hasBackgroundLocationPermission = jest.fn().mockResolvedValueOnce(true);
+    GeolocationService.startBackgroundLocationSharing = jest.fn().mockImplementation(GeolocationService.startBackgroundLocationSharing);
+
+    await GeolocationService.autoStartBackgroundLocationSharing("test");
+
+    expect(GeolocationService.startBackgroundLocationSharing).not.toHaveBeenCalled();
+    expect(BackgroundService.start).not.toHaveBeenCalled();
+});
+
+test('can stop', async () => {
+    await GeolocationService.stopBackgroundLocationSharing();
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith("background-location-sharing", "false");
+    expect(BackgroundService.stop).toHaveBeenCalledTimes(1);
+});

--- a/mobileapp/src/GeolocationService.test.js
+++ b/mobileapp/src/GeolocationService.test.js
@@ -7,6 +7,8 @@ import GeolocationService from './GeolocationService';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import BackgroundService from 'react-native-background-actions';
 
+jest.mock('./Socket');
+
 beforeEach(async () => {
     BackgroundService.start.mockReset();
     BackgroundService.stop.mockReset();

--- a/mobileapp/src/components/Dashboard.js
+++ b/mobileapp/src/components/Dashboard.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button, StyleSheet, Text, View, Switch } from 'react-native';
 import { addLocation } from 'restapi-client';
-import { fetchLocation, isBackgroundLocationSharingRunning, startBackgroundLocationSharing, stopBackgroundLocationSharing, autoStartBackgroundLocationSharing } from '../GeolocationService';
+import GeolocationService from '../GeolocationService';
 
 class Dashboard extends React.Component {
 
@@ -14,18 +14,18 @@ class Dashboard extends React.Component {
   }
 
   async componentDidMount() {
-    await autoStartBackgroundLocationSharing(this.props.context.sessionId);
-    this.setState({ isSharingLocation: isBackgroundLocationSharingRunning() });
+    await GeolocationService.autoStartBackgroundLocationSharing(this.props.context.sessionId);
+    this.setState({ isSharingLocation: GeolocationService.isBackgroundLocationSharingRunning() });
   }
 
   async setIsSharingLocation(value) {
     if (value) {
-      await startBackgroundLocationSharing(this.props.context.sessionId);
+      await GeolocationService.startBackgroundLocationSharing(this.props.context.sessionId);
     } else {
-      await stopBackgroundLocationSharing();
+      await GeolocationService.stopBackgroundLocationSharing();
     }
 
-    this.setState({ isSharingLocation: isBackgroundLocationSharingRunning() });
+    this.setState({ isSharingLocation: GeolocationService.isBackgroundLocationSharingRunning() });
   }
 
   async addLocation()

--- a/mobileapp/src/components/Dashboard.js
+++ b/mobileapp/src/components/Dashboard.js
@@ -64,10 +64,24 @@ class Dashboard extends React.Component {
       }
     </View>
 
-    <View>
-      <Button onPress={this.getLocation.bind(this)} title = "Refresh Location"/>
-      <Button onPress={this.addLocation.bind(this)} title = "Save Location"/>
-      <Switch onValueChange={this.setIsSharingLocation.bind(this)} value={this.state.isSharingLocation}/>
+    <View style={styles.container}>
+      <View style={styles.singleComponentRow}>
+        <Button onPress={this.getLocation.bind(this)} title = "Refresh Location"/>
+      </View>
+      <View style={styles.singleComponentRow}>
+        <Button onPress={this.addLocation.bind(this)} title = "Save Location"/>
+      </View>
+      <View style={styles.singleComponentRow}>
+        <Text style={styles.helpText}>Save your current location. You can view and edit your saved locations through the Radaring web application.</Text>
+      </View>
+      <View style={styles.separator} />
+      <View style={styles.multiComponentRow}>
+        <Text style={styles.label}>Share Location</Text>
+        <Switch onValueChange={this.setIsSharingLocation.bind(this)} value={this.state.isSharingLocation} thumbColor="#2296F3" trackColor={{false: "#B2B2B2", true: "#79bbf2"}}/>
+      </View>
+      <View style={styles.singleComponentRow}>
+        <Text style={styles.helpText}>Enabling this option will share your location with your Solid Pod friends. You will receive notifications from nearby friends.</Text>
+      </View>
     </View>
     </>
   )}
@@ -76,6 +90,39 @@ class Dashboard extends React.Component {
 const styles = StyleSheet.create({
   center: {
     textAlign: "center",
+  },
+  container: {
+    flex: 1,
+    flexDirection: 'column',
+  },
+  singleComponentRow: {
+    justifyContent: 'space-between',
+    padding: 3,
+    marginHorizontal: 20,
+  },
+  multiComponentRow: {
+    flexGrow: 1,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: 3,
+    marginHorizontal: 20,
+  },
+  separator: {
+    borderWidth: 1.5,
+    borderColor: "#b0b0b0",
+    marginHorizontal: 16,
+    marginTop: 8,
+    marginBottom: 6
+  },
+  label: {
+    flexGrow: 1,
+    fontSize: 15,
+    textTransform: 'uppercase'
+  },
+  helpText: {
+    flexGrow: 1,
+    fontSize: 13
   },
 });
 

--- a/mobileapp/src/components/Dashboard.js
+++ b/mobileapp/src/components/Dashboard.js
@@ -9,14 +9,11 @@ class Dashboard extends React.Component {
       super(props);
 
       this.state = {
-        location: undefined,
         isSharingLocation: false,
       }
   }
 
   async componentDidMount() {
-    this.getLocation();
-
     await autoStartBackgroundLocationSharing(this.props.context.sessionId);
     this.setState({ isSharingLocation: isBackgroundLocationSharingRunning() });
   }
@@ -29,19 +26,6 @@ class Dashboard extends React.Component {
     }
 
     this.setState({ isSharingLocation: isBackgroundLocationSharingRunning() });
-  }
-
-
-  getLocation()
-  {
-    this.setState({location: undefined});
-
-    fetchLocation(async (lat, long) => {
-      this.setState({location: {
-        latitude: lat,
-        longitude: long
-      }});
-    });
   }
 
   async addLocation()
@@ -60,17 +44,9 @@ class Dashboard extends React.Component {
     <>
     <View>
       <Text style={styles.center}>Welcome {this.props.name}!</Text>
-      {
-        (this.state.location !== undefined)
-        ? <Text style={styles.center}>Current location: ({this.state.location.latitude}, {this.state.location.longitude})</Text>
-        : <Text style={styles.center}>Fetching location...</Text>
-      }
     </View>
 
     <View style={styles.container}>
-      <View style={styles.singleComponentRow}>
-        <Button onPress={this.getLocation.bind(this)} title = "Refresh Location"/>
-      </View>
       <View style={styles.singleComponentRow}>
         <Button onPress={this.addLocation.bind(this)} title = "Save Location"/>
       </View>

--- a/mobileapp/src/components/Dashboard.js
+++ b/mobileapp/src/components/Dashboard.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Button, StyleSheet, Text, View, Platform, PermissionsAndroid, ToastAndroid, Switch } from 'react-native';
-import { addLocation, updateLastLocation } from 'restapi-client';
-import { fetchLocation, isBackgroundLocationSharingRunning, startBackgroundLocationSharing, stopBackgroundLocationSharing } from '../GeolocationService';
+import { Button, StyleSheet, Text, View, Switch } from 'react-native';
+import { addLocation } from 'restapi-client';
+import { fetchLocation, isBackgroundLocationSharingRunning, startBackgroundLocationSharing, stopBackgroundLocationSharing, autoStartBackgroundLocationSharing } from '../GeolocationService';
 
 class Dashboard extends React.Component {
 
@@ -10,12 +10,15 @@ class Dashboard extends React.Component {
 
       this.state = {
         location: undefined,
-        isSharingLocation: isBackgroundLocationSharingRunning(),
+        isSharingLocation: false,
       }
   }
 
-  componentDidMount() {
+  async componentDidMount() {
     this.getLocation();
+
+    await autoStartBackgroundLocationSharing(this.props.context.sessionId);
+    this.setState({ isSharingLocation: isBackgroundLocationSharingRunning() });
   }
 
   async setIsSharingLocation(value) {

--- a/mobileapp/src/components/session/SessionProvider.js
+++ b/mobileapp/src/components/session/SessionProvider.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { Linking } from 'react-native';
 import { sessionLogin, sessionLogout, sessionInfo, sessionFetch } from "restapi-client";
 import { SessionContext } from "./SessionContext";
-import  { sendRegisterMessage, sendUnregisterMessage } from "../../Socket";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
 /* Provides a SessionContext, using our REST API server for login and session handling.
@@ -35,9 +34,6 @@ export default class SessionProvider extends React.Component {
     urlHandler(ev) {
         this.handleIncomingRedirect(ev.url).then(newState => {
             this.saveSessionToStorage(newState.sessionId, newState.isLoggedIn, newState.webId);
-            if(newState.isLoggedIn) {
-                sendRegisterMessage(newState.sessionId);
-            }
             this.setState(newState);
         })
     }
@@ -82,7 +78,6 @@ export default class SessionProvider extends React.Component {
         this.setLogoutInProgress(true);
         if (this.state.sessionId != null) {
             sessionLogout(this.state.sessionId).then(res => {
-               sendUnregisterMessage();
                 this.setState({
                     sessionId: null,
                     isLoggedIn: false,

--- a/mobileapp/src/components/session/SessionProvider.js
+++ b/mobileapp/src/components/session/SessionProvider.js
@@ -2,7 +2,8 @@ import React from 'react';
 import { Linking } from 'react-native';
 import { sessionLogin, sessionLogout, sessionInfo, sessionFetch } from "restapi-client";
 import { SessionContext } from "./SessionContext";
-import  { sendRegisterMessage, sendUnregisterMessage } from "../../Socket"
+import  { sendRegisterMessage, sendUnregisterMessage } from "../../Socket";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 
 /* Provides a SessionContext, using our REST API server for login and session handling.
  */
@@ -18,17 +19,27 @@ export default class SessionProvider extends React.Component {
             logoutInProgress: false,
             webId: null,
         }
+
+        this.urlHandler = this.urlHandler.bind(this);
     }
 
     componentDidMount() {
-        Linking.addEventListener("url", ev => {
-            this.handleIncomingRedirect(ev.url).then(newState => {
-                if(newState.isLoggedIn) {
-                    sendRegisterMessage(newState.sessionId);
-                }
-                this.setState(newState);
-            })
-        });
+        Linking.addEventListener("url", this.urlHandler);
+        this.restoreSessionFromStorage();
+    }
+
+    componentWillUnmount() {
+        Linking.removeEventListener("url", this.urlHandler);
+    }
+
+    urlHandler(ev) {
+        this.handleIncomingRedirect(ev.url).then(newState => {
+            this.saveSessionToStorage(newState.sessionId, newState.isLoggedIn, newState.webId);
+            if(newState.isLoggedIn) {
+                sendRegisterMessage(newState.sessionId);
+            }
+            this.setState(newState);
+        })
     }
 
     setLoginInProgress(b) {
@@ -123,4 +134,50 @@ export default class SessionProvider extends React.Component {
             };
         }
     }
+
+    async saveSessionToStorage(sessionId, isLoggedIn, webId) {
+        try {
+            const data = JSON.stringify({ sessionId, isLoggedIn, webId });
+            await AsyncStorage.setItem(sessionIdKey, data);
+        } catch (err) {
+            console.log(`failed to save '${sessionIdKey}':`, err);
+        }
+    }
+
+    async restoreSessionFromStorage() {
+        try {
+            const data = await AsyncStorage.getItem(sessionIdKey);
+            if (data !== null) {
+                const { sessionId, isLoggedIn, webId } = JSON.parse(data);
+                if (isLoggedIn) {
+                    this.setLoginInProgress(true);
+                    sessionInfo(sessionId)
+                        .then(newInfo => {
+                            this.setState({
+                                sessionId: sessionId,
+                                isLoggedIn: newInfo.isLoggedIn,
+                                loginInProgress: false,
+                                logoutInProgress: false,
+                                webId: newInfo.webId,
+                            });
+                        })
+                        .catch(err => {
+                            console.log("sessionInfo request failed:", err);
+                            this.saveSessionToStorage(null, false, null);
+                            this.setState({
+                                sessionId: null,
+                                isLoggedIn: false,
+                                loginInProgress: false,
+                                logoutInProgress: false,
+                                webId: null,
+                            });
+                        });
+                }
+            }
+        } catch(err) {
+            console.log(`failed to read '${sessionIdKey}':`, err);
+        }
+    }
 }
+
+const sessionIdKey = "sessionId";

--- a/mobileapp/src/setup-tests.js
+++ b/mobileapp/src/setup-tests.js
@@ -11,5 +11,21 @@ jest.mock('react-native-geolocation-service', () => {
         watchPosition: jest.fn(),
         clearWatch: jest.fn(),
         stopObserving: jest.fn(),
-    }
-})
+    };
+});
+
+jest.mock('react-native-background-actions', () => {
+    return {
+        start: jest.fn(),
+        stop: jest.fn(),
+        isRunning: jest.fn(),
+    };
+});
+
+jest.mock('@react-native-async-storage/async-storage', () => {
+    return {
+        getItem: jest.fn(),
+        setItem: jest.fn(),
+        removeItem: jest.fn(),
+    };
+});

--- a/mobileapp/src/setup-tests.js
+++ b/mobileapp/src/setup-tests.js
@@ -29,3 +29,7 @@ jest.mock('@react-native-async-storage/async-storage', () => {
         removeItem: jest.fn(),
     };
 });
+
+jest.mock('@react-native-async-storage/async-storage');
+
+jest.mock('./components/session/SessionProvider');


### PR DESCRIPTION
Closes #141.

- Location sharing runs in the background without needing to have the mobileapp open all the time using the library [react-native-background-actions](https://github.com/Rapsssito/react-native-background-actions).
- Notifications websocket now only connects when location sharing is running.
- Tweaked the dashboard UI to make it more self-explanatory and allow the user to toggle location sharing.