### PR TITLE
Fix webapp routes when deployed in Heroku

### DIFF
--- a/webapp/src/Routes.js
+++ b/webapp/src/Routes.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { BrowserRouter, Switch, Route, Redirect } from "react-router-dom";
+import { HashRouter, Switch, Route, Redirect } from "react-router-dom";
 
 import DashboardPage from "./pages/dashboard";
 import FriendsPage from "./pages/friends";
@@ -8,7 +8,7 @@ import SettingsPage from "./pages/settings";
 const Routes = (props) => {
   console.log("ROUTER REDIRECTING WITH SESSION INFO: "+ JSON.stringify(props.session));
   return (
-    <BrowserRouter>
+    <HashRouter>
       <Switch>
         <Route path="/friends">
           <FriendsPage />
@@ -28,7 +28,7 @@ const Routes = (props) => {
         </Route>
         
       </Switch>
-    </BrowserRouter>
+    </HashRouter>
   );
 };
 

--- a/webapp/src/components/MyMenu.js
+++ b/webapp/src/components/MyMenu.js
@@ -26,14 +26,14 @@ class MyMenu extends React.Component {
   {
     let nav = [ this.navItem,  
       {
-        title: <a href="/dashboard">Home</a>,
+        title: <a href="#/dashboard">Home</a>,
         itemId: '/dashboard',
         // you can use your own custom Icon component as well
         // icon is optional
         elemBefore: () => <Icon name="map-pin" />
       },
       {
-        title: <a href="/friends">Friends</a>,
+        title: <a href="#/friends">Friends</a>,
         itemId: '/friends', // TODO go to friends page
         // you can use your own custom Icon component as well
         // icon is optional
@@ -42,7 +42,7 @@ class MyMenu extends React.Component {
 
     if (isAdmin) {
       nav.push({
-        title: <a href="/settings">Settings</a>,
+        title: <a href="#/settings">Settings</a>,
         itemId: '/settings',
         elemBefore: () => <Icon name="settings" />,
       });


### PR DESCRIPTION
Fixes #159.

Now using HashRouter instead of BrowserRouter. Routes are like `/#/dashboard` instead of `/dashboard`.